### PR TITLE
Support Ruby 2.4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,7 @@ jobs:
     strategy:
       matrix:
         ruby:
+          - 2.4.10
           - 2.5.9
           - 2.6.7
           - 2.7.3
@@ -33,6 +34,12 @@ jobs:
           - gemfiles/sidekiq_5.2.x.gemfile
           - gemfiles/sidekiq_6.1.x.gemfile
         exclude:
+          - ruby: 2.4.10
+            gemfile: gemfiles/activejob_6.0.x.gemfile
+          - ruby: 2.4.10
+            gemfile: gemfiles/activejob_6.1.x.gemfile
+          - ruby: 2.4.10
+            gemfile: gemfiles/sidekiq_6.1.x.gemfile
           - ruby: 2.7.2
             gemfile: gemfiles/activejob_4.2.x.gemfile
           - ruby: 2.7.2

--- a/activejob-uniqueness.gemspec
+++ b/activejob-uniqueness.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
 
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.5'
+  spec.required_ruby_version = '>= 2.4'
 
   spec.add_dependency 'activejob', '>= 4.2', '< 7'
   spec.add_dependency 'redlock', '>= 1.2', '< 2'


### PR DESCRIPTION
Add Ruby 2.4 for older projects that are a little bit late on upgrading to Ruby 2.5+
Yes it is already EOL but that will help some of us.